### PR TITLE
Add stat group and SmashGame definition + add top 6 melee character stats

### DIFF
--- a/src/SmashGame/Melee.json
+++ b/src/SmashGame/Melee.json
@@ -1,0 +1,96 @@
+{
+  "name": "Melee",
+  "characters": [
+    {
+      "name": "Fox",
+      "stats": {
+        "weight": 1.00,
+        "punishibility": 1.25,
+        "recovery": 1.20,
+        "csm": {
+          "tech_skill": 0.90,
+          "neutral_game": 1.15,
+          "luck": 0.75,
+          "punish_game": 1.20,
+          "edgegaurding": 1.15
+        }
+      }
+    },
+    {
+      "name": "Falco",
+      "stats": {
+        "weight": 1.00,
+        "punishibility": 1.25,
+        "recovery": 1.00,
+        "csm": {
+          "tech_skill": 0.95,
+          "neutral_game": 1.20,
+          "luck": 0.85,
+          "punish_game": 1.20,
+          "edgegaurding": 0.95
+        }
+      }
+    },
+    {
+      "name": "Marth",
+      "stats": {
+        "weight": 1.00,
+        "punishibility": 0.95,
+        "recovery": 1.15,
+        "csm": {
+          "tech_skill": 1.10,
+          "neutral_game": 1.25,
+          "luck": 0.65,
+          "punish_game": 1.05,
+          "edgegaurding": 1.25
+        }
+      }
+    },
+    {
+      "name": "Sheik",
+      "stats": {
+        "weight": 1.00,
+        "punishibility": 0.85,
+        "recovery": 1.00,
+        "csm": {
+          "tech_skill": 1.15,
+          "neutral_game": 1.10,
+          "luck": 0.80,
+          "punish_game": 1.25,
+          "edgegaurding": 1.25
+        }
+      }
+    },
+    {
+      "name": "Peach",
+      "stats": {
+        "weight": 0.85,
+        "punishibility": 0.80,
+        "recovery": 1.25,
+        "csm": {
+          "tech_skill": 1.00,
+          "neutral_game": 1.00,
+          "luck": 1.25,
+          "punish_game": 1.15,
+          "edgegaurding": 1.15
+        }
+      }
+    },
+    {
+      "name": "Puff",
+      "stats": {
+        "weight": 0.75,
+        "punishibility": 0.85,
+        "recovery": 1.25,
+        "csm": {
+          "tech_skill": 1.20,
+          "neutral_game": 1.10,
+          "luck": 0.75,
+          "punish_game": 1.20,
+          "edgegaurding": 1.20
+        }
+      }
+    }
+  ],
+  "stages": ["not-yet-implemented"]
+}

--- a/src/SmashGame/SmashGame.js
+++ b/src/SmashGame/SmashGame.js
@@ -1,0 +1,31 @@
+"use strict"
+/* SmashGame class */
+
+module.exports = class SmashGame
+{
+  /**
+   * @param {Object} config             describes starting state of smash game
+   * @param {String} config.name        game name
+   * @param {Array}  config.characters  array of characters that make up the game
+   * @param {Array}  config.stages      array of available stages in the game
+   */
+  constructor(config)
+  {
+    this.config = config;
+  }
+
+  get name()
+  {
+    return this.config.name;
+  }
+
+  get characters()
+  {
+    return this.config.characters;
+  }
+
+  get stages()
+  {
+    return this.config.stages;
+  }
+}

--- a/src/Stats/StatGroup.js
+++ b/src/Stats/StatGroup.js
@@ -1,0 +1,30 @@
+"use strict"
+/* StatGroup class */
+
+module.exports = class StatGroup
+{
+  /**
+   * @param {Object} config        describes starting state of the stat group
+   * @param {String} config.name   Name of the stat group
+   * @param {Object} config.stats  The `name: value` pairs that make up the stat group
+   *
+   */
+  constructor(config)
+  {
+    this.config = config;
+  }
+
+  get name()
+  {
+    return this.config.name;
+  }
+
+  /**
+   * @param {String} name  Name of the specific stat
+   *
+   * @returns {value}  The value of the object
+   */
+  stat(name) {
+    return this.config.stats[name];
+  }
+}


### PR DESCRIPTION
Pretty straightforward PR. Just serializing the stats Dan made using the structure we will be using for games and characters.

Also adds `StatGroup` class to be used for stats groups later (not for character stats).
