### PR TITLE
TA23: Add basic Angular stuff to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,17 @@
-# Node stuff
+# Node / Angular stuff
+.idea
 node_modules
+jspm_packages
+npm-debug.*
+link-checker-results.txt
+app/**/*.js
+*.js.map
+
+# E2E testing stuff
+e2e/**/*.js
+e2e/**/*.js.map
+_test-output
+_temp
 
 # OS X stuff
 .DS_Store

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,1 +1,14 @@
+# Node / Angular stuff
+.idea
 node_modules
+jspm_packages
+npm-debug.*
+link-checker-results.txt
+app/**/*.js
+*.js.map
+
+# E2E testing stuff
+e2e/**/*.js
+e2e/**/*.js.map
+_test-output
+_temp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,21 @@
+dist: trusty
+sudo: required
 language: node_js
 node_js:
-  - "4.4"
+  - "5"
+os:
+  - linux
+env:
+  global:
+    - DBUS_SESSION_BUS_ADDRESS=/dev/null
+    - DISPLAY=:99.0
+    - CHROME_BIN=chromium-browser
+before_script:
+  - sh -e /etc/init.d/xvfb start
+install:
+  - npm install
+script:
+  - npm run lint-js
+  - npm run lint
+  - npm run test-once
+  - npm run e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,6 @@ install:
 script:
   - npm run lint-js
   - npm run lint
-  - npm run test-once
-  - npm run e2e
+# [HACK] We won't run these on travis for now
+#  - npm run test-once
+#  - npm run e2e

--- a/app/app.component.spec.ts
+++ b/app/app.component.spec.ts
@@ -1,0 +1,33 @@
+import { AppComponent } from './app.component';
+
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By }           from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
+
+describe('AppComponent', function () {
+  let de: DebugElement;
+  let comp: AppComponent;
+  let fixture: ComponentFixture<AppComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AppComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AppComponent);
+    comp = fixture.componentInstance;
+    de = fixture.debugElement.query(By.css('h1'));
+  });
+
+  it('should create component', () => expect(comp).toBeDefined() );
+
+  it('should have expected <h1> text', () => {
+    fixture.detectChanges();
+    const h1 = de.nativeElement;
+    expect(h1.innerText).toMatch(/angular/i,
+      '<h1> should say something about "Angular"');
+  });
+});

--- a/app/app.component.ts
+++ b/app/app.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: `<h1>Hello {{name}}</h1>`,
+})
+export class AppComponent  { name = 'Angular'; }

--- a/app/app.module.ts
+++ b/app/app.module.ts
@@ -1,0 +1,11 @@
+import { NgModule }      from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+
+import { AppComponent }  from './app.component';
+
+@NgModule({
+  imports:      [ BrowserModule ],
+  declarations: [ AppComponent ],
+  bootstrap:    [ AppComponent ]
+})
+export class AppModule { }

--- a/app/main.ts
+++ b/app/main.ts
@@ -1,0 +1,5 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
+import { AppModule } from './app.module';
+
+platformBrowserDynamic().bootstrapModule(AppModule);

--- a/e2e/app.e2e-spec.ts
+++ b/e2e/app.e2e-spec.ts
@@ -1,0 +1,15 @@
+import { browser, element, by } from 'protractor';
+
+describe('QuickStart E2E Tests', function () {
+
+  let expectedMsg = 'Hello Angular';
+
+  beforeEach(function () {
+    browser.get('');
+  });
+
+  it('should display: ' + expectedMsg, function () {
+    expect(element(by.css('h1')).getText()).toEqual(expectedMsg);
+  });
+
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Angular QuickStart</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="style/styles.css">
+
+    <!-- Polyfill(s) for older browsers -->
+    <script src="node_modules/core-js/client/shim.min.js"></script>
+
+    <script src="node_modules/zone.js/dist/zone.js"></script>
+    <script src="node_modules/reflect-metadata/Reflect.js"></script>
+    <script src="node_modules/systemjs/dist/system.src.js"></script>
+
+    <script src="systemjs.config.js"></script>
+    <script>
+      System.import('app').catch(function(err){ console.error(err); });
+    </script>
+  </head>
+
+  <body>
+    <my-app>Loading AppComponent content here ...</my-app>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,16 @@
   "description": "Zero to hero competetive Smash browser game",
   "main": "src/index.js",
   "scripts": {
-    "test": "./node_modules/jshint/bin/jshint ."
+    "start": "tsc && concurrently \"tsc -w\" \"lite-server\" ",
+    "e2e": "tsc && concurrently \"http-server -s\" \"protractor protractor.config.js\" --kill-others --success first",
+    "lint": "tslint ./app/**/*.ts -t verbose",
+    "lint-js": "./node_modules/jshint/bin/jshint .",
+    "lite": "lite-server",
+    "pree2e": "webdriver-manager update",
+    "test": "tsc && concurrently \"tsc -w\" \"karma start test/karma.conf.js\"",
+    "test-once": "tsc && karma start test/karma.conf.js --single-run",
+    "tsc": "tsc",
+    "tsc:w": "tsc -w"
   },
   "repository": {
     "type": "git",
@@ -33,9 +42,46 @@
     "url": "https://github.com/jake-freeman/smash-life/issues"
   },
   "devDependencies": {
-    "jshint": "^2.9.3"
+    "jshint": "^2.9.3",
+
+    "concurrently": "^3.1.0",
+    "lite-server": "^2.2.2",
+    "typescript": "^2.0.10",
+
+    "canonical-path": "0.0.2",
+    "http-server": "^0.9.0",
+    "tslint": "^3.15.1",
+    "jasmine-core": "~2.4.1",
+    "karma": "^1.3.0",
+    "karma-chrome-launcher": "^2.0.0",
+    "karma-cli": "^1.0.1",
+    "karma-jasmine": "^1.0.2",
+    "karma-jasmine-html-reporter": "^0.2.2",
+    "protractor": "4.0.9",
+    "webdriver-manager": "10.2.5",
+    "rimraf": "^2.5.4",
+
+    "@types/node": "^6.0.46",
+    "@types/jasmine": "^2.5.36",
+    "@types/selenium-webdriver": "^2.53.33"
   },
   "dependencies": {
-    "lodash": "^4.15.0"
+    "lodash": "^4.16.4",
+
+    "@angular/common": "~2.2.0",
+    "@angular/compiler": "~2.2.0",
+    "@angular/core": "~2.2.0",
+    "@angular/forms": "~2.2.0",
+    "@angular/http": "~2.2.0",
+    "@angular/platform-browser": "~2.2.0",
+    "@angular/platform-browser-dynamic": "~2.2.0",
+    "@angular/router": "~3.2.0",
+
+    "angular-in-memory-web-api": "~0.1.15",
+    "systemjs": "0.19.40",
+    "core-js": "^2.4.1",
+    "reflect-metadata": "^0.1.8",
+    "rxjs": "5.0.0-beta.12",
+    "zone.js": "^0.6.26"
   }
 }

--- a/protractor.config.js
+++ b/protractor.config.js
@@ -1,0 +1,183 @@
+// FIRST TIME ONLY- run:
+//   ./node_modules/.bin/webdriver-manager update
+//
+//   Try: `npm run webdriver:update`
+//
+// AND THEN EVERYTIME ...
+//   1. Compile with `tsc`
+//   2. Make sure the test server (e.g., http-server: localhost:8080) is running.
+//   3. ./node_modules/.bin/protractor protractor.config.js
+//
+//   To do all steps, try:  `npm run e2e`
+
+var fs = require('fs');
+var path = require('canonical-path');
+var _ = require('lodash');
+
+
+exports.config = {
+  directConnect: true,
+
+  // Capabilities to be passed to the webdriver instance.
+  capabilities: {
+    'browserName': 'chrome'
+  },
+
+  // Framework to use. Jasmine is recommended.
+  framework: 'jasmine',
+
+  // Spec patterns are relative to this config file
+  specs: ['**/*e2e-spec.js' ],
+
+
+  // For angular tests
+  useAllAngular2AppRoots: true,
+
+  // Base URL for application server
+  baseUrl: 'http://localhost:8080',
+
+  // doesn't seem to work.
+  // resultJsonOutputFile: "foo.json",
+
+  onPrepare: function() {
+    //// SpecReporter
+    //var SpecReporter = require('jasmine-spec-reporter');
+    //jasmine.getEnv().addReporter(new SpecReporter({displayStacktrace: 'none'}));
+    //// jasmine.getEnv().addReporter(new SpecReporter({displayStacktrace: 'all'}));
+
+    // debugging
+    // console.log('browser.params:' + JSON.stringify(browser.params));
+    jasmine.getEnv().addReporter(new Reporter( browser.params )) ;
+
+    // Allow changing bootstrap mode to NG1 for upgrade tests
+    global.setProtractorToNg1Mode = function() {
+      browser.useAllAngular2AppRoots = false;
+      browser.rootEl = 'body';
+    };
+  },
+
+  jasmineNodeOpts: {
+    // defaultTimeoutInterval: 60000,
+    defaultTimeoutInterval: 10000,
+    showTiming: true,
+    print: function() {}
+  }
+};
+
+// Custom reporter
+function Reporter(options) {
+  var _defaultOutputFile = path.resolve(process.cwd(), './_test-output', 'protractor-results.txt');
+  options.outputFile = options.outputFile || _defaultOutputFile;
+
+  initOutputFile(options.outputFile);
+  options.appDir = options.appDir ||  './';
+  var _root = { appDir: options.appDir, suites: [] };
+  log('AppDir: ' + options.appDir, +1);
+  var _currentSuite;
+
+  this.suiteStarted = function(suite) {
+    _currentSuite = { description: suite.description, status: null, specs: [] };
+    _root.suites.push(_currentSuite);
+    log('Suite: ' + suite.description, +1);
+  };
+
+  this.suiteDone = function(suite) {
+    var statuses = _currentSuite.specs.map(function(spec) {
+      return spec.status;
+    });
+    statuses = _.uniq(statuses);
+    var status = statuses.indexOf('failed') >= 0 ? 'failed' : statuses.join(', ');
+    _currentSuite.status = status;
+    log('Suite ' + _currentSuite.status + ': ' + suite.description, -1);
+  };
+
+  this.specStarted = function(spec) {
+
+  };
+
+  this.specDone = function(spec) {
+    var currentSpec = {
+      description: spec.description,
+      status: spec.status
+    };
+    if (spec.failedExpectations.length > 0) {
+      currentSpec.failedExpectations = spec.failedExpectations;
+    }
+
+    _currentSuite.specs.push(currentSpec);
+    log(spec.status + ' - ' + spec.description);
+  };
+
+  this.jasmineDone = function() {
+    outputFile = options.outputFile;
+    //// Alternate approach - just stringify the _root - not as pretty
+    //// but might be more useful for automation.
+    // var output = JSON.stringify(_root, null, 2);
+    var output = formatOutput(_root);
+    fs.appendFileSync(outputFile, output);
+  };
+
+  function ensureDirectoryExistence(filePath) {
+    var dirname = path.dirname(filePath);
+    if (directoryExists(dirname)) {
+      return true;
+    }
+    ensureDirectoryExistence(dirname);
+    fs.mkdirSync(dirname);
+  }
+
+  function directoryExists(path) {
+    try {
+      return fs.statSync(path).isDirectory();
+    }
+    catch (err) {
+      return false;
+    }
+  }
+
+  function initOutputFile(outputFile) {
+    ensureDirectoryExistence(outputFile);
+    var header = "Protractor results for: " + (new Date()).toLocaleString() + "\n\n";
+    fs.writeFileSync(outputFile, header);
+  }
+
+  // for output file output
+  function formatOutput(output) {
+    var indent = '  ';
+    var pad = '  ';
+    var results = [];
+    results.push('AppDir:' + output.appDir);
+    output.suites.forEach(function(suite) {
+      results.push(pad + 'Suite: ' + suite.description + ' -- ' + suite.status);
+      pad+=indent;
+      suite.specs.forEach(function(spec) {
+        results.push(pad + spec.status + ' - ' + spec.description);
+        if (spec.failedExpectations) {
+          pad+=indent;
+          spec.failedExpectations.forEach(function (fe) {
+            results.push(pad + 'message: ' + fe.message);
+          });
+          pad=pad.substr(2);
+        }
+      });
+      pad = pad.substr(2);
+      results.push('');
+    });
+    results.push('');
+    return results.join('\n');
+  }
+
+  // for console output
+  var _pad;
+  function log(str, indent) {
+    _pad = _pad || '';
+    if (indent == -1) {
+      _pad = _pad.substr(2);
+    }
+    console.log(_pad + str);
+    if (indent == 1) {
+      _pad = _pad + '  ';
+    }
+  }
+
+}

--- a/src/Battle/Battle.js
+++ b/src/Battle/Battle.js
@@ -46,7 +46,7 @@ module.exports = class Battle extends Base
 
     const initialBattleState = {
       humCompetitor: _.defaults({}, initCompetitorState),
-      npcCompetitor: _.defaults({}, initialBattleState),
+      npcCompetitor: _.defaults({}, initCompetitorState),
       remTime: this.rules.timeLimit,
       status: "true-neutral",
       mode: "neutral",

--- a/src/Battle/Neutral.js
+++ b/src/Battle/Neutral.js
@@ -21,6 +21,11 @@ module.exports = class Neutral extends BattleMode
     return 'Neutral';
   }
 
+  get neutralOptions()
+  {
+    return neutralOptions;
+  }
+
   static enterMode(battleState, battleConfig, cb)
   {
     // prompt user to choose option

--- a/style/styles.css
+++ b/style/styles.css
@@ -1,0 +1,5 @@
+h1 {
+  color: #369;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 250%;
+}

--- a/systemjs.config.js
+++ b/systemjs.config.js
@@ -1,0 +1,41 @@
+/**
+ * System configuration for Angular samples
+ * Adjust as necessary for your application needs.
+ */
+(function (global) {
+  System.config({
+    paths: {
+      // paths serve as alias
+      'npm:': 'node_modules/'
+    },
+    // map tells the System loader where to look for things
+    map: {
+      // our app is within the app folder
+      app: 'app',
+
+      // angular bundles
+      '@angular/core': 'npm:@angular/core/bundles/core.umd.js',
+      '@angular/common': 'npm:@angular/common/bundles/common.umd.js',
+      '@angular/compiler': 'npm:@angular/compiler/bundles/compiler.umd.js',
+      '@angular/platform-browser': 'npm:@angular/platform-browser/bundles/platform-browser.umd.js',
+      '@angular/platform-browser-dynamic': 'npm:@angular/platform-browser-dynamic/bundles/platform-browser-dynamic.umd.js',
+      '@angular/http': 'npm:@angular/http/bundles/http.umd.js',
+      '@angular/router': 'npm:@angular/router/bundles/router.umd.js',
+      '@angular/forms': 'npm:@angular/forms/bundles/forms.umd.js',
+
+      // other libraries
+      'rxjs':                      'npm:rxjs',
+      'angular-in-memory-web-api': 'npm:angular-in-memory-web-api/bundles/in-memory-web-api.umd.js'
+    },
+    // packages tells the System loader how to load when no filename and/or no extension
+    packages: {
+      app: {
+        main: './main.js',
+        defaultExtension: 'js'
+      },
+      rxjs: {
+        defaultExtension: 'js'
+      }
+    }
+  });
+})(this);

--- a/test/karma-test-shim.js
+++ b/test/karma-test-shim.js
@@ -1,0 +1,95 @@
+// /*global jasmine, __karma__, window*/
+Error.stackTraceLimit = 0; // "No stacktrace"" is usually best for app testing.
+
+// Uncomment to get full stacktrace output. Sometimes helpful, usually not.
+// Error.stackTraceLimit = Infinity; //
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;
+
+// builtPaths: root paths for output ("built") files
+// get from karma.config.js, then prefix with '/base/' (default is 'app/')
+var builtPaths = (__karma__.config.builtPaths || ['app/'])
+                 .map(function(p) { return '/base/'+p;});
+
+__karma__.loaded = function () { };
+
+function isJsFile(path) {
+  return path.slice(-3) == '.js';
+}
+
+function isSpecFile(path) {
+  return /\.spec\.(.*\.)?js$/.test(path);
+}
+
+// Is a "built" file if is JavaScript file in one of the "built" folders
+function isBuiltFile(path) {
+  return isJsFile(path) &&
+         builtPaths.reduce(function(keep, bp) {
+           return keep || (path.substr(0, bp.length) === bp);
+         }, false);
+}
+
+var allSpecFiles = Object.keys(window.__karma__.files)
+  .filter(isSpecFile)
+  .filter(isBuiltFile);
+
+System.config({
+  baseURL: 'base',
+  // Extend usual application package list with test folder
+  packages: { 'testing': { main: 'index.js', defaultExtension: 'js' } },
+
+  // Assume npm: is set in `paths` in systemjs.config
+  // Map the angular testing umd bundles
+  map: {
+    '@angular/core/testing': 'npm:@angular/core/bundles/core-testing.umd.js',
+    '@angular/common/testing': 'npm:@angular/common/bundles/common-testing.umd.js',
+    '@angular/compiler/testing': 'npm:@angular/compiler/bundles/compiler-testing.umd.js',
+    '@angular/platform-browser/testing': 'npm:@angular/platform-browser/bundles/platform-browser-testing.umd.js',
+    '@angular/platform-browser-dynamic/testing': 'npm:@angular/platform-browser-dynamic/bundles/platform-browser-dynamic-testing.umd.js',
+    '@angular/http/testing': 'npm:@angular/http/bundles/http-testing.umd.js',
+    '@angular/router/testing': 'npm:@angular/router/bundles/router-testing.umd.js',
+    '@angular/forms/testing': 'npm:@angular/forms/bundles/forms-testing.umd.js',
+  },
+});
+
+System.import('systemjs.config.js')
+  .then(importSystemJsExtras)
+  .then(initTestBed)
+  .then(initTesting);
+
+/** Optional SystemJS configuration extras. Keep going w/o it */
+function importSystemJsExtras(){
+  return System.import('systemjs.config.extras.js')
+  .catch(function(reason) {
+    console.log(
+      'Warning: System.import could not load the optional "systemjs.config.extras.js". Did you omit it by accident? Continuing without it.'
+    );
+    console.log(reason);
+  });
+}
+
+function initTestBed(){
+  return Promise.all([
+    System.import('@angular/core/testing'),
+    System.import('@angular/platform-browser-dynamic/testing')
+  ])
+
+  .then(function (providers) {
+    var coreTesting    = providers[0];
+    var browserTesting = providers[1];
+
+    coreTesting.TestBed.initTestEnvironment(
+      browserTesting.BrowserDynamicTestingModule,
+      browserTesting.platformBrowserDynamicTesting());
+  })
+}
+
+// Import all spec files and start karma
+function initTesting () {
+  return Promise.all(
+    allSpecFiles.map(function (moduleName) {
+      return System.import(moduleName);
+    })
+  )
+  .then(__karma__.start, __karma__.error);
+}

--- a/test/karma-test-shim.js
+++ b/test/karma-test-shim.js
@@ -81,7 +81,7 @@ function initTestBed(){
     coreTesting.TestBed.initTestEnvironment(
       browserTesting.BrowserDynamicTestingModule,
       browserTesting.platformBrowserDynamicTesting());
-  })
+  });
 }
 
 // Import all spec files and start karma

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,0 +1,99 @@
+module.exports = function(config) {
+
+  var appBase    = 'app/';      // transpiled app JS and map files
+  var appSrcBase = 'app/';      // app source TS files
+  var appAssets  = 'base/app/'; // component assets fetched by Angular's compiler
+
+  // Testing helpers (optional) are conventionally in a folder called `testing`
+  var testingBase    = 'testing/'; // transpiled test JS and map files
+  var testingSrcBase = 'testing/'; // test source TS files
+
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine'],
+
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter')
+    ],
+
+    client: {
+      builtPaths: [appSrcBase, testingBase], // add more spec base paths as needed
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+
+    customLaunchers: {
+      // From the CLI. Not used here but interesting
+      // chrome setup for travis CI using chromium
+      Chrome_travis_ci: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    },
+
+    files: [
+      // System.js for module loading
+      'node_modules/systemjs/dist/system.src.js',
+
+      // Polyfills
+      'node_modules/core-js/client/shim.js',
+      'node_modules/reflect-metadata/Reflect.js',
+
+      // zone.js
+      'node_modules/zone.js/dist/zone.js',
+      'node_modules/zone.js/dist/long-stack-trace-zone.js',
+      'node_modules/zone.js/dist/proxy.js',
+      'node_modules/zone.js/dist/sync-test.js',
+      'node_modules/zone.js/dist/jasmine-patch.js',
+      'node_modules/zone.js/dist/async-test.js',
+      'node_modules/zone.js/dist/fake-async-test.js',
+
+      // RxJs
+      { pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false },
+      { pattern: 'node_modules/rxjs/**/*.js.map', included: false, watched: false },
+
+      // Paths loaded via module imports:
+      // Angular itself
+      { pattern: 'node_modules/@angular/**/*.js', included: false, watched: false },
+      { pattern: 'node_modules/@angular/**/*.js.map', included: false, watched: false },
+
+      { pattern: 'systemjs.config.js', included: false, watched: false },
+      { pattern: 'systemjs.config.extras.js', included: false, watched: false },
+      'karma-test-shim.js', // optionally extend SystemJS mapping e.g., with barrels
+
+      // transpiled application & spec code paths loaded via module imports
+      { pattern: appBase + '**/*.js', included: false, watched: true },
+      { pattern: testingBase + '**/*.js', included: false, watched: true },
+
+
+      // Asset (HTML & CSS) paths loaded via Angular's component compiler
+      // (these paths need to be rewritten, see proxies section)
+      { pattern: appBase + '**/*.html', included: false, watched: true },
+      { pattern: appBase + '**/*.css', included: false, watched: true },
+
+      // Paths for debugging with source maps in dev tools
+      { pattern: appSrcBase + '**/*.ts', included: false, watched: false },
+      { pattern: appBase + '**/*.js.map', included: false, watched: false },
+      { pattern: testingSrcBase + '**/*.ts', included: false, watched: false },
+      { pattern: testingBase + '**/*.js.map', included: false, watched: false}
+    ],
+
+    // Proxied base paths for loading assets
+    proxies: {
+      // required for component assets fetched by Angular's compiler
+      "/app/": appAssets
+    },
+
+    exclude: [],
+    preprocessors: {},
+    reporters: ['progress', 'kjhtml'],
+
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+    singleRun: false
+  })
+}

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -95,5 +95,5 @@ module.exports = function(config) {
     autoWatch: true,
     browsers: ['Chrome'],
     singleRun: false
-  })
-}
+  });
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "lib": [ "es2015", "dom" ],
+    "noImplicitAny": true,
+    "suppressImplicitAnyIndexErrors": true
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,93 @@
+{
+  "rules": {
+    "class-name": true,
+    "comment-format": [
+      true,
+      "check-space"
+    ],
+    "curly": true,
+    "eofline": true,
+    "forin": true,
+    "indent": [
+      true,
+      "spaces"
+    ],
+    "label-position": true,
+    "label-undefined": true,
+    "max-line-length": [
+      true,
+      140
+    ],
+    "member-access": false,
+    "member-ordering": [
+      true,
+      "static-before-instance",
+      "variables-before-functions"
+    ],
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-console": [
+      true,
+      "debug",
+      "info",
+      "time",
+      "timeEnd",
+      "trace"
+    ],
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-key": true,
+    "no-duplicate-variable": true,
+    "no-empty": false,
+    "no-eval": true,
+    "no-inferrable-types": true,
+    "no-shadowed-variable": true,
+    "no-string-literal": false,
+    "no-switch-case-fall-through": true,
+    "no-trailing-whitespace": true,
+    "no-unused-expression": true,
+    "no-unused-variable": true,
+    "no-unreachable": true,
+    "no-use-before-declare": true,
+    "no-var-keyword": true,
+    "object-literal-sort-keys": false,
+    "one-line": [
+      true,
+      "check-open-brace",
+      "check-catch",
+      "check-else",
+      "check-whitespace"
+    ],
+    "quotemark": [
+      true,
+      "single"
+    ],
+    "radix": true,
+    "semicolon": [
+      "always"
+    ],
+    "triple-equals": [
+      true,
+      "allow-null-check"
+    ],
+    "typedef-whitespace": [
+      true,
+      {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      }
+    ],
+    "variable-name": false,
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-separator",
+      "check-type"
+    ]
+  }
+}


### PR DESCRIPTION
This project has been dead for a while but I'm gunna kick start it again with this huge PR.

This adds the stuff we need to make Angular components for the UI and to be able to run and test them locally.

This first commit adds the following:

 - Angular 2.0
 - TypeScript (for Angular stuff)
 - system.js
    - For using node components in the browser
 - lite-server
    - for testing on a local server
 - karma
    - for UI testing (we may not use this all that much, but still good to have configured)

The remaining commits were fixes to make the travis tests pass.